### PR TITLE
fix(l2tp): encode Call Serial Number AVP as uint32

### DIFF
--- a/android/app/src/main/cpp/l2tp.c
+++ b/android/app/src/main/cpp/l2tp.c
@@ -613,10 +613,11 @@ static int l2tp_handshake_inner(int esp_fd, esp_keys_t *esp, const struct sockad
   ao = 0;
   avp_u16(avps, &ao, L2TP_AVP_MSG_TYPE, L2TP_MSG_ICRQ);
   avp_u16(avps, &ao, L2TP_AVP_ASSIGNED_SESSION, local_sid);
-  avp_u16(avps, &ao, 15, 1);
+  if (l2tp_avp_append_u32(avps, sizeof(avps), &ao, L2TP_AVP_CALL_SERIAL, 1u) != 0)
+    return -1;
   tunnel_engine_log(ANDROID_LOG_DEBUG, LOG_TAG,
                     "l2tp icrq avps: msg_type=%u assigned_session=%u call_serial=%u call_serial_width=%u",
-                    (unsigned)L2TP_MSG_ICRQ, (unsigned)local_sid, 1u, 16u);
+                    (unsigned)L2TP_MSG_ICRQ, (unsigned)local_sid, 1u, 32u);
   if (send_ctrl(esp_fd, esp, peer, peer_len, s, avps, ao) != 0)
     return -1;
 

--- a/android/app/src/main/cpp/l2tp_avps.c
+++ b/android/app/src/main/cpp/l2tp_avps.c
@@ -29,6 +29,12 @@ int l2tp_avp_append_u16(uint8_t *buf, size_t cap, size_t *off, uint16_t attr_typ
   return l2tp_avp_append_raw(buf, cap, off, attr_type, tmp, sizeof(tmp));
 }
 
+int l2tp_avp_append_u32(uint8_t *buf, size_t cap, size_t *off, uint16_t attr_type, uint32_t value) {
+  uint8_t tmp[4];
+  util_write_be32(tmp, value);
+  return l2tp_avp_append_raw(buf, cap, off, attr_type, tmp, sizeof(tmp));
+}
+
 int l2tp_avp_append_result(uint8_t *buf, size_t cap, size_t *off, uint16_t result_code, uint16_t error_code) {
   uint8_t tmp[4];
   util_write_be16(tmp + 0, result_code);

--- a/android/app/src/main/cpp/l2tp_avps.h
+++ b/android/app/src/main/cpp/l2tp_avps.h
@@ -8,6 +8,7 @@
 #define L2TP_AVP_RESULT_CODE 1
 #define L2TP_AVP_ASSIGNED_TUNNEL 9
 #define L2TP_AVP_ASSIGNED_SESSION 14
+#define L2TP_AVP_CALL_SERIAL 15
 
 #define L2TP_MSG_SCCRQ 1
 #define L2TP_MSG_SCCRP 2
@@ -24,6 +25,9 @@
 
 /** Append a mandatory uint16 AVP to an AVP buffer. */
 int l2tp_avp_append_u16(uint8_t *buf, size_t cap, size_t *off, uint16_t attr_type, uint16_t value);
+
+/** Append a mandatory uint32 AVP to an AVP buffer. */
+int l2tp_avp_append_u32(uint8_t *buf, size_t cap, size_t *off, uint16_t attr_type, uint32_t value);
 
 /** Append a mandatory Result Code AVP with result+error and no message. */
 int l2tp_avp_append_result(uint8_t *buf, size_t cap, size_t *off, uint16_t result_code, uint16_t error_code);

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -284,10 +284,10 @@ packages:
     dependency: "direct dev"
     description:
       name: flutter_native_splash
-      sha256: "4fb9f4113350d3a80841ce05ebf1976a36de622af7d19aca0ca9a9911c7ff002"
+      sha256: "9db4b80b044e9af17cc4b1272137fc7ace0054d879ef8210a76adc34aaf4cdff"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.7"
+    version: "2.4.8"
   flutter_plugin_android_lifecycle:
     dependency: transitive
     description:
@@ -520,10 +520,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.18"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
@@ -536,10 +536,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   mime:
     dependency: transitive
     description:
@@ -909,26 +909,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "54c516bbb7cee2754d327ad4fca637f78abfc3cbcc5ace83b3eda117e42cd71a"
+      sha256: "8d9ceddbab833f180fbefed08afa76d7c03513dfdba87ffcec2718b02bbcbf20"
       url: "https://pub.dev"
     source: hosted
-    version: "1.29.0"
+    version: "1.31.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.9"
+    version: "0.7.11"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "394f07d21f0f2255ec9e3989f21e54d3c7dc0e6e9dbce160e5a9c1a6be0e2943"
+      sha256: "1991d4cfe85d5043241acac92962c3977c8d2f2add1ee73130c7b286417d1d34"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.15"
+    version: "0.6.17"
   typed_data:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: tunnel_forge
 description: TunnelForge - L2TP/IPsec VPN for Android.
 publish_to: "none"
 
-version: 0.7.4+204
+version: 0.7.5+205
 
 environment:
   sdk: ^3.11.0

--- a/test/native/test_l2tp_avps.c
+++ b/test/native/test_l2tp_avps.c
@@ -133,6 +133,15 @@ int main(void) {
   if (assigned_session != 0x687fu) return fail("cdn assigned session value");
 
   ao = 0;
+  if (l2tp_avp_append_u32(avps, sizeof(avps), &ao, L2TP_AVP_CALL_SERIAL, 0x01020304u) != 0) {
+    return fail("append call serial");
+  }
+  if (ao != 10u) return fail("call serial length");
+  if (util_read_be16(avps + 0) != 0x800au) return fail("call serial avp length");
+  if (util_read_be16(avps + 4) != L2TP_AVP_CALL_SERIAL) return fail("call serial type");
+  if (util_read_be32(avps + 6) != 0x01020304u) return fail("call serial value");
+
+  ao = 0;
   memset(pkt, 0, sizeof(pkt));
   if (l2tp_avp_append_u16(avps, sizeof(avps), &ao, L2TP_AVP_MSG_TYPE, L2TP_MSG_STOPCCN) != 0) {
     return fail("append stop msg type");


### PR DESCRIPTION
Fixes #7

  - Encode the L2TP Call Serial Number AVP as a 4-octet uint32.
  - Add a native regression test for the AVP width.
  - Bump the app version to 0.7.5+205.