### PR TITLE
Add PPP EAP-MSCHAPv2 authentication

### DIFF
--- a/android/app/src/main/cpp/CMakeLists.txt
+++ b/android/app/src/main/cpp/CMakeLists.txt
@@ -50,6 +50,7 @@ add_library(
   esp_udp.c
   l2tp_avps.c
   l2tp.c
+  ppp_eap_mschap.c
   ppp_mschap.c
   ppp.c
 )

--- a/android/app/src/main/cpp/ppp.c
+++ b/android/app/src/main/cpp/ppp.c
@@ -8,6 +8,7 @@
 #include "engine.h"
 #include "esp_udp.h"
 #include "ipv4_dataplane.h"
+#include "ppp_eap_mschap.h"
 #include "ppp_mschap.h"
 
 #include <android/log.h>
@@ -26,6 +27,7 @@
 #define PROTO_LCP 0xc021u
 #define PROTO_PAP 0xc023u
 #define PROTO_CHAP 0xc223u
+#define PROTO_EAP 0xc227u
 #define PROTO_IPCP 0x8021u
 /** IPv6CP (IANA / RFC 5072); gateway may offer after IPv4 IPCP - we send LCP Protocol-Reject. */
 #define PROTO_IPV6CP 0x8057u
@@ -36,6 +38,7 @@
 typedef enum {
   PPP_AUTH_PAP = 0,
   PPP_AUTH_MSCHAPV2,
+  PPP_AUTH_EAP_MSCHAPV2,
   PPP_AUTH_CHAP_MD5,
 } ppp_auth_kind_t;
 
@@ -45,6 +48,8 @@ static const char *ppp_auth_name(ppp_auth_kind_t auth) {
     return "pap";
   case PPP_AUTH_MSCHAPV2:
     return "mschapv2";
+  case PPP_AUTH_EAP_MSCHAPV2:
+    return "eap-mschapv2";
   case PPP_AUTH_CHAP_MD5:
     return "chap-md5";
   default:
@@ -247,6 +252,10 @@ static int lcp_build_cr(uint8_t *out, size_t cap, uint8_t id, ppp_auth_kind_t au
       out[o++] = 0xc2;
       out[o++] = 0x23;
       out[o++] = 0x81;
+    } else if (auth == PPP_AUTH_EAP_MSCHAPV2) {
+      out[o++] = 4;
+      util_write_be16(out + o, PROTO_EAP);
+      o += 2;
     } else {
       /* RFC 1994 CHAP: Authentication-Protocol 0xc223 + algorithm 0x05 (MD5-Challenge). */
       out[o++] = 5;
@@ -275,6 +284,10 @@ static int lcp_parse_peer_auth(const uint8_t *lcp, size_t lcp_len, ppp_auth_kind
       uint16_t proto = ((uint16_t)opts[i + 2u] << 8) | opts[i + 3u];
       if (proto == PROTO_PAP) {
         *out = PPP_AUTH_PAP;
+        return 0;
+      }
+      if (proto == PROTO_EAP) {
+        *out = PPP_AUTH_EAP_MSCHAPV2;
         return 0;
       }
       if (proto == 0xc223u && ol >= 5u) {
@@ -565,8 +578,11 @@ static int ppp_lcp_negotiate(int esp_fd, esp_keys_t *esp, const struct sockaddr 
     if (code == 3 && rid == id) {
       /* Configure-Nak: adopt suggested auth family and resend with next id. */
       uint16_t lcp_len = util_read_be16(p + 4);
-      if (lcp_len >= 6 && (size_t)lcp_len <= len) {
-        if (lcp_nak_wants_pap(p + 6, (size_t)lcp_len - 6)) {
+      if (lcp_len >= 6u && (size_t)lcp_len + 2u <= len) {
+        ppp_auth_kind_t suggested_auth = auth;
+        if (lcp_parse_peer_auth(p + 2u, (size_t)lcp_len, &suggested_auth) == 0) {
+          auth = suggested_auth;
+        } else if (lcp_nak_wants_pap(p + 6, (size_t)lcp_len - 6)) {
           auth = PPP_AUTH_PAP;
         } else {
           auth = PPP_AUTH_CHAP_MD5;
@@ -714,6 +730,168 @@ static int ppp_auth_mschapv2(int esp_fd, esp_keys_t *esp, const struct sockaddr 
       }
     }
     return -1;
+  }
+  return -1;
+}
+
+static int ppp_send_eap(int esp_fd, esp_keys_t *esp, const struct sockaddr *peer, socklen_t peer_len,
+                        l2tp_session_t *l2tp, const uint8_t *eap, size_t eap_len) {
+  uint8_t frame[768];
+  if (eap == NULL || eap_len + 4u > sizeof(frame))
+    return -1;
+  frame[0] = 0xff;
+  frame[1] = 0x03;
+  util_write_be16(frame + 2u, PROTO_EAP);
+  memcpy(frame + 4u, eap, eap_len);
+  return send_ppp(esp_fd, esp, peer, peer_len, l2tp, frame, eap_len + 4u);
+}
+
+static void ppp_log_eap_mschapv2_failure(const uint8_t *message, size_t message_len) {
+  ppp_mschapv2_failure_info_t failure;
+  if (ppp_mschapv2_parse_failure(message, message_len, &failure) == 0) {
+    char err[16];
+    char retry[16];
+    char version[16];
+    snprintf(err, sizeof(err), failure.has_error_code ? "%d" : "-", failure.error_code);
+    snprintf(retry, sizeof(retry), failure.has_retry ? "%d" : "-", failure.retry);
+    snprintf(version, sizeof(version), failure.has_version ? "%d" : "-", failure.version);
+    tunnel_engine_log(ANDROID_LOG_ERROR, LOG_TAG, "ppp: EAP MS-CHAPv2 failure E=%s R=%s V=%s M=%s", err, retry, version,
+                      failure.has_message ? failure.message : "-");
+  } else {
+    tunnel_engine_log(ANDROID_LOG_ERROR, LOG_TAG, "ppp: EAP MS-CHAPv2 failure");
+  }
+}
+
+/** EAP type 26 wrapper for MS-CHAPv2, as negotiated by PPP Authentication-Protocol 0xc227. */
+static int ppp_auth_eap_mschapv2(int esp_fd, esp_keys_t *esp, const struct sockaddr *peer, socklen_t peer_len,
+                                 l2tp_session_t *l2tp, const char *user, const char *password) {
+  uint8_t in[4096];
+  uint8_t response_eap[640];
+  int response_eap_len = -1;
+  uint8_t challenge_eap_id = 0u;
+  uint8_t challenge_mschap_id = 0u;
+  uint8_t success_eap_id = 0u;
+  int success_acknowledged = 0;
+  uint8_t expected_authenticator_response[20];
+  tunnel_engine_log(ANDROID_LOG_DEBUG, LOG_TAG, "ppp auth: start eap-mschapv2");
+
+  for (int i = 0; i < 16 && response_eap_len < 0; i++) {
+    int n = recv_ppp(esp_fd, esp, l2tp, in, sizeof(in), 5000);
+    if (n <= 0)
+      continue;
+    const uint8_t *p = in;
+    size_t len = (size_t)n;
+    ppp_strip(in, (size_t)n, &p, &len);
+    uint16_t proto = 0u;
+    size_t proto_len = 0u;
+    if (ppp_read_protocol(p, len, &proto, &proto_len) != 0 || proto != PROTO_EAP || len < proto_len + 4u)
+      continue;
+    const uint8_t *eap = p + proto_len;
+    size_t eap_len = len - proto_len;
+    uint8_t identity_id = 0u;
+    if (ppp_eap_parse_identity_request(eap, eap_len, &identity_id) == 0) {
+      uint8_t identity_response[512];
+      int identity_response_len =
+          ppp_eap_build_identity_response(identity_response, sizeof(identity_response), identity_id, user);
+      if (identity_response_len < 0 ||
+          ppp_send_eap(esp_fd, esp, peer, peer_len, l2tp, identity_response, (size_t)identity_response_len) < 0)
+        return -1;
+      tunnel_engine_log(ANDROID_LOG_DEBUG, LOG_TAG, "ppp auth: sent eap identity response id=%u bytes=%d",
+                        (unsigned)identity_id, identity_response_len);
+      continue;
+    }
+    ppp_eap_mschapv2_challenge_t challenge;
+    if (ppp_eap_mschapv2_parse_challenge(eap, eap_len, &challenge) != 0) {
+      ppp_log_rx_summary(p, len, "auth-eap-mschapv2-skip");
+      continue;
+    }
+    ppp_log_rx_summary(p, len, "auth-eap-mschapv2-challenge");
+    uint8_t peer_chal[16];
+    if (urandom_bytes(peer_chal, sizeof(peer_chal)) != 0)
+      return -1;
+    uint8_t val49[49];
+    if (ppp_mschapv2_response_value(user, password, challenge.challenge, peer_chal, val49) != 0)
+      return -1;
+    if (ppp_mschapv2_authenticator_response(user, password, challenge.challenge, peer_chal, val49 + 24u,
+                                            expected_authenticator_response) != 0)
+      return -1;
+    response_eap_len = ppp_eap_mschapv2_build_response(response_eap, sizeof(response_eap), challenge.eap_identifier,
+                                                       challenge.mschapv2_identifier, val49, user);
+    if (response_eap_len < 0)
+      return -1;
+    challenge_eap_id = challenge.eap_identifier;
+    challenge_mschap_id = challenge.mschapv2_identifier;
+    if (ppp_send_eap(esp_fd, esp, peer, peer_len, l2tp, response_eap, (size_t)response_eap_len) < 0)
+      return -1;
+    tunnel_engine_log(ANDROID_LOG_DEBUG, LOG_TAG,
+                      "ppp auth: sent eap-mschapv2 response eap_id=%u mschap_id=%u bytes=%d",
+                      (unsigned)challenge_eap_id, (unsigned)challenge_mschap_id, response_eap_len);
+  }
+  if (response_eap_len < 0)
+    return -1;
+
+  for (int i = 0; i < 16; i++) {
+    int n = recv_ppp(esp_fd, esp, l2tp, in, sizeof(in), 5000);
+    if (n <= 0)
+      continue;
+    const uint8_t *p = in;
+    size_t len = (size_t)n;
+    ppp_strip(in, (size_t)n, &p, &len);
+    uint16_t proto = 0u;
+    size_t proto_len = 0u;
+    if (ppp_read_protocol(p, len, &proto, &proto_len) != 0 || proto != PROTO_EAP || len < proto_len + 4u)
+      continue;
+    const uint8_t *eap = p + proto_len;
+    size_t eap_len = len - proto_len;
+
+    uint8_t terminal_code = 0u;
+    uint8_t terminal_id = 0u;
+    if (ppp_eap_parse_terminal(eap, eap_len, &terminal_code, &terminal_id) == 0) {
+      tunnel_engine_log(terminal_code == PPP_EAP_CODE_SUCCESS ? ANDROID_LOG_DEBUG : ANDROID_LOG_ERROR, LOG_TAG,
+                        "ppp auth: terminal EAP code=%u id=%u", (unsigned)terminal_code, (unsigned)terminal_id);
+      if (terminal_code == PPP_EAP_CODE_FAILURE)
+        return -1;
+      if (success_acknowledged && terminal_id == success_eap_id)
+        return 0;
+      tunnel_engine_log(ANDROID_LOG_WARN, LOG_TAG, "ppp auth: ignored premature or mismatched EAP Success id=%u",
+                        (unsigned)terminal_id);
+      continue;
+    }
+
+    ppp_eap_mschapv2_challenge_t duplicate;
+    if (ppp_eap_mschapv2_parse_challenge(eap, eap_len, &duplicate) == 0 &&
+        duplicate.eap_identifier == challenge_eap_id && duplicate.mschapv2_identifier == challenge_mschap_id) {
+      if (ppp_send_eap(esp_fd, esp, peer, peer_len, l2tp, response_eap, (size_t)response_eap_len) < 0)
+        return -1;
+      tunnel_engine_log(ANDROID_LOG_DEBUG, LOG_TAG, "ppp auth: resent eap-mschapv2 response id=%u",
+                        (unsigned)challenge_eap_id);
+      continue;
+    }
+
+    ppp_eap_mschapv2_result_t result;
+    if (ppp_eap_mschapv2_parse_result(eap, eap_len, &result) != 0)
+      continue;
+    ppp_log_rx_summary(p, len,
+                       result.opcode == PPP_EAP_MSCHAPV2_OP_SUCCESS ? "auth-eap-mschapv2-success-request"
+                                                                    : "auth-eap-mschapv2-failure-request");
+    if (result.opcode == PPP_EAP_MSCHAPV2_OP_SUCCESS &&
+        ppp_eap_mschapv2_verify_authenticator_response(result.message, result.message_len,
+                                                       expected_authenticator_response) != 0) {
+      tunnel_engine_log(ANDROID_LOG_ERROR, LOG_TAG, "ppp auth: invalid eap-mschapv2 authenticator response");
+      return -1;
+    }
+    uint8_t result_response[6];
+    if (ppp_eap_mschapv2_build_result_response(result_response, result.eap_identifier, result.opcode) < 0 ||
+        ppp_send_eap(esp_fd, esp, peer, peer_len, l2tp, result_response, sizeof(result_response)) < 0)
+      return -1;
+    if (result.opcode == PPP_EAP_MSCHAPV2_OP_FAILURE) {
+      ppp_log_eap_mschapv2_failure(result.message, result.message_len);
+      return -1;
+    }
+    tunnel_engine_log(ANDROID_LOG_DEBUG, LOG_TAG, "ppp auth: acknowledged eap-mschapv2 success request id=%u",
+                      (unsigned)result.eap_identifier);
+    success_eap_id = result.eap_identifier;
+    success_acknowledged = 1;
   }
   return -1;
 }
@@ -1349,6 +1527,11 @@ int ppp_negotiate(int esp_fd, esp_keys_t *esp, const struct sockaddr *peer, sock
   if (auth == PPP_AUTH_MSCHAPV2) {
     if (ppp_auth_mschapv2(esp_fd, esp, peer, peer_len, l2tp, user, password) != 0) {
       tunnel_engine_log(ANDROID_LOG_ERROR, LOG_TAG, "ppp negotiate: auth failure method=mschapv2");
+      return -1;
+    }
+  } else if (auth == PPP_AUTH_EAP_MSCHAPV2) {
+    if (ppp_auth_eap_mschapv2(esp_fd, esp, peer, peer_len, l2tp, user, password) != 0) {
+      tunnel_engine_log(ANDROID_LOG_ERROR, LOG_TAG, "ppp negotiate: auth failure method=eap-mschapv2");
       return -1;
     }
   } else if (auth == PPP_AUTH_CHAP_MD5) {

--- a/android/app/src/main/cpp/ppp_eap_mschap.c
+++ b/android/app/src/main/cpp/ppp_eap_mschap.c
@@ -1,0 +1,143 @@
+#include "ppp_eap_mschap.h"
+
+#include <string.h>
+
+static uint16_t eap_read_be16(const uint8_t *p) { return (uint16_t)(((uint16_t)p[0] << 8) | p[1]); }
+
+static void eap_write_be16(uint8_t *p, uint16_t value) {
+  p[0] = (uint8_t)(value >> 8);
+  p[1] = (uint8_t)(value & 0xffu);
+}
+
+static int eap_packet_length(const uint8_t *eap, size_t len, uint16_t *packet_len_out) {
+  if (eap == NULL || packet_len_out == NULL || len < 4u)
+    return -1;
+  uint16_t packet_len = eap_read_be16(eap + 2u);
+  if (packet_len < 4u || (size_t)packet_len > len)
+    return -1;
+  *packet_len_out = packet_len;
+  return 0;
+}
+
+int ppp_eap_parse_identity_request(const uint8_t *eap, size_t len, uint8_t *identifier_out) {
+  uint16_t packet_len = 0u;
+  if (identifier_out == NULL || eap_packet_length(eap, len, &packet_len) != 0 || packet_len < 5u)
+    return -1;
+  if (eap[0] != PPP_EAP_CODE_REQUEST || eap[4] != PPP_EAP_TYPE_IDENTITY)
+    return -1;
+  *identifier_out = eap[1];
+  return 0;
+}
+
+int ppp_eap_build_identity_response(uint8_t *out, size_t cap, uint8_t identifier, const char *username) {
+  if (out == NULL || username == NULL)
+    return -1;
+  size_t username_len = strlen(username);
+  size_t packet_len = 5u + username_len;
+  if (packet_len > cap || packet_len > UINT16_MAX)
+    return -1;
+  out[0] = PPP_EAP_CODE_RESPONSE;
+  out[1] = identifier;
+  eap_write_be16(out + 2u, (uint16_t)packet_len);
+  out[4] = PPP_EAP_TYPE_IDENTITY;
+  memcpy(out + 5u, username, username_len);
+  return (int)packet_len;
+}
+
+int ppp_eap_mschapv2_parse_challenge(const uint8_t *eap, size_t len, ppp_eap_mschapv2_challenge_t *out) {
+  uint16_t packet_len = 0u;
+  if (out == NULL || eap_packet_length(eap, len, &packet_len) != 0 || packet_len < 26u)
+    return -1;
+  if (eap[0] != PPP_EAP_CODE_REQUEST || eap[4] != PPP_EAP_TYPE_MSCHAPV2 || eap[5] != PPP_EAP_MSCHAPV2_OP_CHALLENGE)
+    return -1;
+  uint16_t ms_len = eap_read_be16(eap + 7u);
+  if (ms_len != (uint16_t)(packet_len - 5u) || eap[9] != 16u)
+    return -1;
+  out->eap_identifier = eap[1];
+  out->mschapv2_identifier = eap[6];
+  out->challenge = eap + 10u;
+  return 0;
+}
+
+int ppp_eap_mschapv2_build_response(uint8_t *out, size_t cap, uint8_t eap_identifier, uint8_t mschapv2_identifier,
+                                    const uint8_t value49[49], const char *username) {
+  if (out == NULL || value49 == NULL || username == NULL)
+    return -1;
+  size_t username_len = strlen(username);
+  size_t packet_len = 10u + 49u + username_len;
+  if (packet_len > cap || packet_len > UINT16_MAX)
+    return -1;
+  out[0] = PPP_EAP_CODE_RESPONSE;
+  out[1] = eap_identifier;
+  eap_write_be16(out + 2u, (uint16_t)packet_len);
+  out[4] = PPP_EAP_TYPE_MSCHAPV2;
+  out[5] = PPP_EAP_MSCHAPV2_OP_RESPONSE;
+  out[6] = mschapv2_identifier;
+  eap_write_be16(out + 7u, (uint16_t)(packet_len - 5u));
+  out[9] = 49u;
+  memcpy(out + 10u, value49, 49u);
+  memcpy(out + 59u, username, username_len);
+  return (int)packet_len;
+}
+
+int ppp_eap_mschapv2_parse_result(const uint8_t *eap, size_t len, ppp_eap_mschapv2_result_t *out) {
+  uint16_t packet_len = 0u;
+  if (out == NULL || eap_packet_length(eap, len, &packet_len) != 0 || packet_len < 9u)
+    return -1;
+  if (eap[0] != PPP_EAP_CODE_REQUEST || eap[4] != PPP_EAP_TYPE_MSCHAPV2 ||
+      (eap[5] != PPP_EAP_MSCHAPV2_OP_SUCCESS && eap[5] != PPP_EAP_MSCHAPV2_OP_FAILURE))
+    return -1;
+  if (eap_read_be16(eap + 7u) != (uint16_t)(packet_len - 5u))
+    return -1;
+  out->eap_identifier = eap[1];
+  out->opcode = eap[5];
+  out->message = eap + 9u;
+  out->message_len = (size_t)packet_len - 9u;
+  return 0;
+}
+
+static int eap_hex_value(uint8_t c) {
+  if (c >= (uint8_t)'0' && c <= (uint8_t)'9')
+    return (int)(c - (uint8_t)'0');
+  if (c >= (uint8_t)'A' && c <= (uint8_t)'F')
+    return 10 + (int)(c - (uint8_t)'A');
+  return -1;
+}
+
+int ppp_eap_mschapv2_verify_authenticator_response(const uint8_t *message, size_t message_len,
+                                                   const uint8_t expected_digest[20]) {
+  if (message == NULL || expected_digest == NULL || message_len < 42u || message[0] != (uint8_t)'S' ||
+      message[1] != (uint8_t)'=')
+    return -1;
+  unsigned int difference = 0u;
+  for (size_t i = 0; i < 20u; i++) {
+    int high = eap_hex_value(message[2u + (i * 2u)]);
+    int low = eap_hex_value(message[3u + (i * 2u)]);
+    if (high < 0 || low < 0)
+      return -1;
+    difference |= (unsigned int)(((high << 4) | low) ^ expected_digest[i]);
+  }
+  return difference == 0u ? 0 : -1;
+}
+
+int ppp_eap_mschapv2_build_result_response(uint8_t out[6], uint8_t eap_identifier, uint8_t opcode) {
+  if (out == NULL || (opcode != PPP_EAP_MSCHAPV2_OP_SUCCESS && opcode != PPP_EAP_MSCHAPV2_OP_FAILURE))
+    return -1;
+  out[0] = PPP_EAP_CODE_RESPONSE;
+  out[1] = eap_identifier;
+  eap_write_be16(out + 2u, 6u);
+  out[4] = PPP_EAP_TYPE_MSCHAPV2;
+  out[5] = opcode;
+  return 6;
+}
+
+int ppp_eap_parse_terminal(const uint8_t *eap, size_t len, uint8_t *code_out, uint8_t *identifier_out) {
+  uint16_t packet_len = 0u;
+  if (code_out == NULL || identifier_out == NULL || eap_packet_length(eap, len, &packet_len) != 0 || packet_len != 4u)
+    return -1;
+  if (eap[0] != PPP_EAP_CODE_SUCCESS && eap[0] != PPP_EAP_CODE_FAILURE)
+    return -1;
+  *code_out = eap[0];
+  *identifier_out = eap[1];
+  return 0;
+}

--- a/android/app/src/main/cpp/ppp_eap_mschap.h
+++ b/android/app/src/main/cpp/ppp_eap_mschap.h
@@ -1,0 +1,57 @@
+#ifndef TUNNEL_FORGE_PPP_EAP_MSCHAP_H
+#define TUNNEL_FORGE_PPP_EAP_MSCHAP_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#define PPP_EAP_CODE_REQUEST 1u
+#define PPP_EAP_CODE_RESPONSE 2u
+#define PPP_EAP_CODE_SUCCESS 3u
+#define PPP_EAP_CODE_FAILURE 4u
+#define PPP_EAP_TYPE_IDENTITY 1u
+#define PPP_EAP_TYPE_MSCHAPV2 26u
+#define PPP_EAP_MSCHAPV2_OP_CHALLENGE 1u
+#define PPP_EAP_MSCHAPV2_OP_RESPONSE 2u
+#define PPP_EAP_MSCHAPV2_OP_SUCCESS 3u
+#define PPP_EAP_MSCHAPV2_OP_FAILURE 4u
+
+typedef struct {
+  uint8_t eap_identifier;
+  uint8_t mschapv2_identifier;
+  const uint8_t *challenge;
+} ppp_eap_mschapv2_challenge_t;
+
+typedef struct {
+  uint8_t eap_identifier;
+  uint8_t opcode;
+  const uint8_t *message;
+  size_t message_len;
+} ppp_eap_mschapv2_result_t;
+
+/** Parse an EAP-Request/Identity and return the identifier to echo in the response. */
+int ppp_eap_parse_identity_request(const uint8_t *eap, size_t len, uint8_t *identifier_out);
+
+/** Build an EAP-Response/Identity containing the PPP username. */
+int ppp_eap_build_identity_response(uint8_t *out, size_t cap, uint8_t identifier, const char *username);
+
+/** Parse an EAP-Request/MS-CHAPv2 Challenge. The input starts at the EAP Code field. */
+int ppp_eap_mschapv2_parse_challenge(const uint8_t *eap, size_t len, ppp_eap_mschapv2_challenge_t *out);
+
+/** Build an EAP-Response/MS-CHAPv2 Response around the RFC 2759 49-byte response value. */
+int ppp_eap_mschapv2_build_response(uint8_t *out, size_t cap, uint8_t eap_identifier, uint8_t mschapv2_identifier,
+                                    const uint8_t value49[49], const char *username);
+
+/** Parse an EAP-Request/MS-CHAPv2 Success or Failure packet. */
+int ppp_eap_mschapv2_parse_result(const uint8_t *eap, size_t len, ppp_eap_mschapv2_result_t *out);
+
+/** Verify the RFC 2759 `S=` value at the start of an MS-CHAPv2 Success message. */
+int ppp_eap_mschapv2_verify_authenticator_response(const uint8_t *message, size_t message_len,
+                                                   const uint8_t expected_digest[20]);
+
+/** Build the six-byte EAP-Response/MS-CHAPv2 Success or Failure acknowledgement. */
+int ppp_eap_mschapv2_build_result_response(uint8_t out[6], uint8_t eap_identifier, uint8_t opcode);
+
+/** Parse a four-byte terminal EAP-Success or EAP-Failure packet. */
+int ppp_eap_parse_terminal(const uint8_t *eap, size_t len, uint8_t *code_out, uint8_t *identifier_out);
+
+#endif

--- a/android/app/src/main/cpp/ppp_mschap.c
+++ b/android/app/src/main/cpp/ppp_mschap.c
@@ -132,3 +132,55 @@ int ppp_mschapv2_response_value(const char *username, const char *password, cons
   value49_out[48] = 0;
   return 0;
 }
+
+int ppp_mschapv2_authenticator_response(const char *username, const char *password, const uint8_t auth_challenge[16],
+                                        const uint8_t peer_challenge[16], const uint8_t nt_response[24],
+                                        uint8_t digest_out[20]) {
+  static const uint8_t magic1[] = "Magic server to client signing constant";
+  static const uint8_t magic2[] = "Pad to make it do more than one iteration";
+  uint8_t password_hash[16];
+  uint8_t password_hash_hash[16];
+  uint8_t challenge[8];
+  uint8_t first_digest[20];
+
+  if (username == NULL || password == NULL || auth_challenge == NULL || peer_challenge == NULL || nt_response == NULL ||
+      digest_out == NULL)
+    return -1;
+  if (nt_password_hash(password, password_hash) != 0)
+    return -1;
+
+  mbedtls_md4_context md4;
+  mbedtls_md4_init(&md4);
+  if (mbedtls_md4_starts_ret(&md4) != 0 || mbedtls_md4_update_ret(&md4, password_hash, sizeof(password_hash)) != 0 ||
+      mbedtls_md4_finish_ret(&md4, password_hash_hash) != 0) {
+    mbedtls_md4_free(&md4);
+    return -1;
+  }
+  mbedtls_md4_free(&md4);
+
+  mbedtls_sha1_context sha1;
+  mbedtls_sha1_init(&sha1);
+  if (mbedtls_sha1_starts_ret(&sha1) != 0 ||
+      mbedtls_sha1_update_ret(&sha1, password_hash_hash, sizeof(password_hash_hash)) != 0 ||
+      mbedtls_sha1_update_ret(&sha1, nt_response, 24u) != 0 ||
+      mbedtls_sha1_update_ret(&sha1, magic1, sizeof(magic1) - 1u) != 0 ||
+      mbedtls_sha1_finish_ret(&sha1, first_digest) != 0) {
+    mbedtls_sha1_free(&sha1);
+    return -1;
+  }
+  mbedtls_sha1_free(&sha1);
+
+  if (challenge_hash(peer_challenge, auth_challenge, username, challenge) != 0)
+    return -1;
+
+  mbedtls_sha1_init(&sha1);
+  if (mbedtls_sha1_starts_ret(&sha1) != 0 || mbedtls_sha1_update_ret(&sha1, first_digest, sizeof(first_digest)) != 0 ||
+      mbedtls_sha1_update_ret(&sha1, challenge, sizeof(challenge)) != 0 ||
+      mbedtls_sha1_update_ret(&sha1, magic2, sizeof(magic2) - 1u) != 0 ||
+      mbedtls_sha1_finish_ret(&sha1, digest_out) != 0) {
+    mbedtls_sha1_free(&sha1);
+    return -1;
+  }
+  mbedtls_sha1_free(&sha1);
+  return 0;
+}

--- a/android/app/src/main/cpp/ppp_mschap.h
+++ b/android/app/src/main/cpp/ppp_mschap.h
@@ -20,6 +20,11 @@ typedef struct {
 int ppp_mschapv2_response_value(const char *username, const char *password, const uint8_t auth_challenge[16],
                                 uint8_t peer_challenge[16], uint8_t value49_out[49]);
 
+/** RFC 2759 GenerateAuthenticatorResponse digest before the `S=` hexadecimal encoding. */
+int ppp_mschapv2_authenticator_response(const char *username, const char *password, const uint8_t auth_challenge[16],
+                                        const uint8_t peer_challenge[16], const uint8_t nt_response[24],
+                                        uint8_t digest_out[20]);
+
 /** Consume ASCII digits at *idx; @return 0 and set *out when at least one digit read. */
 static inline int ppp_mschapv2_parse_uint_token(const uint8_t *p, size_t len, size_t *idx, int *out) {
   int value = 0;

--- a/test/native/CMakeLists.txt
+++ b/test/native/CMakeLists.txt
@@ -26,6 +26,10 @@ add_executable(test_ppp_mschap_failure test_ppp_mschap_failure.c)
 target_include_directories(test_ppp_mschap_failure PRIVATE ../../android/app/src/main/cpp)
 add_test(NAME ppp_mschap_failure COMMAND test_ppp_mschap_failure)
 
+add_executable(test_ppp_eap_mschap test_ppp_eap_mschap.c ../../android/app/src/main/cpp/ppp_eap_mschap.c)
+target_include_directories(test_ppp_eap_mschap PRIVATE ../../android/app/src/main/cpp)
+add_test(NAME ppp_eap_mschap COMMAND test_ppp_eap_mschap)
+
 add_executable(test_ppp_frame test_ppp_frame.c)
 add_test(NAME ppp_frame COMMAND test_ppp_frame)
 

--- a/test/native/test_ppp_eap_mschap.c
+++ b/test/native/test_ppp_eap_mschap.c
@@ -1,0 +1,154 @@
+#include "ppp_eap_mschap.h"
+
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+static int test_identity_exchange(void) {
+  const uint8_t request[] = {PPP_EAP_CODE_REQUEST, 3u, 0u, 9u, PPP_EAP_TYPE_IDENTITY, 'N', 'a', 'm', 'e'};
+  uint8_t identifier = 0u;
+  if (ppp_eap_parse_identity_request(request, sizeof(request), &identifier) != 0 || identifier != 3u)
+    return 1;
+  uint8_t response[32];
+  int n = ppp_eap_build_identity_response(response, sizeof(response), identifier, "alice");
+  const uint8_t expected[] = {PPP_EAP_CODE_RESPONSE, 3u, 0u, 10u, PPP_EAP_TYPE_IDENTITY, 'a', 'l', 'i', 'c', 'e'};
+  if (n != (int)sizeof(expected) || memcmp(response, expected, sizeof(expected)) != 0)
+    return 2;
+  if (ppp_eap_build_identity_response(response, 9u, identifier, "alice") >= 0)
+    return 3;
+  uint8_t malformed[sizeof(request)];
+  memcpy(malformed, request, sizeof(request));
+  malformed[3] = 10u;
+  if (ppp_eap_parse_identity_request(malformed, sizeof(malformed), &identifier) == 0)
+    return 4;
+  malformed[3] = (uint8_t)sizeof(malformed);
+  malformed[4] = PPP_EAP_TYPE_MSCHAPV2;
+  if (ppp_eap_parse_identity_request(malformed, sizeof(malformed), &identifier) == 0)
+    return 5;
+  return 0;
+}
+
+static int test_parse_challenge(void) {
+  uint8_t eap[42] = {PPP_EAP_CODE_REQUEST,          7, 0, 42, PPP_EAP_TYPE_MSCHAPV2,
+                     PPP_EAP_MSCHAPV2_OP_CHALLENGE, 9, 0, 37, 16};
+  for (size_t i = 0; i < 16u; i++)
+    eap[10u + i] = (uint8_t)(0xa0u + i);
+  memcpy(eap + 26u, "auth.example.test", 16u);
+  ppp_eap_mschapv2_challenge_t parsed;
+  if (ppp_eap_mschapv2_parse_challenge(eap, sizeof(eap), &parsed) != 0)
+    return 1;
+  if (parsed.eap_identifier != 7u || parsed.mschapv2_identifier != 9u)
+    return 2;
+  if (memcmp(parsed.challenge, eap + 10u, 16u) != 0)
+    return 3;
+  eap[9] = 15u;
+  if (ppp_eap_mschapv2_parse_challenge(eap, sizeof(eap), &parsed) == 0)
+    return 4;
+  eap[9] = 16u;
+  eap[8]--;
+  if (ppp_eap_mschapv2_parse_challenge(eap, sizeof(eap), &parsed) == 0)
+    return 5;
+  return 0;
+}
+
+static int test_build_response(void) {
+  uint8_t value49[49];
+  for (size_t i = 0; i < sizeof(value49); i++)
+    value49[i] = (uint8_t)i;
+  uint8_t out[128];
+  int n = ppp_eap_mschapv2_build_response(out, sizeof(out), 7u, 9u, value49, "alice");
+  if (n != 64)
+    return 1;
+  if (out[0] != PPP_EAP_CODE_RESPONSE || out[1] != 7u || out[2] != 0u || out[3] != 64u)
+    return 2;
+  if (out[4] != PPP_EAP_TYPE_MSCHAPV2 || out[5] != PPP_EAP_MSCHAPV2_OP_RESPONSE || out[6] != 9u)
+    return 3;
+  if (out[7] != 0u || out[8] != 59u || out[9] != 49u)
+    return 4;
+  if (memcmp(out + 10u, value49, sizeof(value49)) != 0 || memcmp(out + 59u, "alice", 5u) != 0)
+    return 5;
+  return 0;
+}
+
+static int test_result_exchange(void) {
+  static const uint8_t message[] = "S=000102030405060708090A0B0C0D0E0F10111213";
+  uint8_t request[9u + sizeof(message) - 1u];
+  size_t request_len = sizeof(request);
+  request[0] = PPP_EAP_CODE_REQUEST;
+  request[1] = 8u;
+  request[2] = (uint8_t)(request_len >> 8);
+  request[3] = (uint8_t)request_len;
+  request[4] = PPP_EAP_TYPE_MSCHAPV2;
+  request[5] = PPP_EAP_MSCHAPV2_OP_SUCCESS;
+  request[6] = 9u;
+  request[7] = (uint8_t)((request_len - 5u) >> 8);
+  request[8] = (uint8_t)(request_len - 5u);
+  memcpy(request + 9u, message, sizeof(message) - 1u);
+  ppp_eap_mschapv2_result_t parsed;
+  if (ppp_eap_mschapv2_parse_result(request, request_len, &parsed) != 0)
+    return 1;
+  if (parsed.eap_identifier != 8u || parsed.opcode != PPP_EAP_MSCHAPV2_OP_SUCCESS ||
+      parsed.message_len != sizeof(message) - 1u)
+    return 2;
+  uint8_t response[6];
+  if (ppp_eap_mschapv2_build_result_response(response, 8u, parsed.opcode) != 6)
+    return 3;
+  const uint8_t expected[6] = {2u, 8u, 0u, 6u, 26u, 3u};
+  if (memcmp(response, expected, sizeof(expected)) != 0)
+    return 4;
+  const uint8_t expected_digest[20] = {0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09,
+                                       0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10, 0x11, 0x12, 0x13};
+  if (ppp_eap_mschapv2_verify_authenticator_response(parsed.message, parsed.message_len, expected_digest) != 0)
+    return 5;
+  request[11] = (uint8_t)'F';
+  if (ppp_eap_mschapv2_verify_authenticator_response(parsed.message, parsed.message_len, expected_digest) == 0)
+    return 6;
+  request[11] = (uint8_t)'4';
+  request[8]--;
+  if (ppp_eap_mschapv2_parse_result(request, request_len, &parsed) == 0)
+    return 7;
+  return 0;
+}
+
+static int test_terminal(void) {
+  uint8_t terminal[4] = {PPP_EAP_CODE_SUCCESS, 8u, 0u, 4u};
+  uint8_t code = 0u;
+  uint8_t identifier = 0u;
+  if (ppp_eap_parse_terminal(terminal, sizeof(terminal), &code, &identifier) != 0)
+    return 1;
+  if (code != PPP_EAP_CODE_SUCCESS || identifier != 8u)
+    return 2;
+  terminal[3] = 5u;
+  if (ppp_eap_parse_terminal(terminal, sizeof(terminal), &code, &identifier) == 0)
+    return 3;
+  return 0;
+}
+
+int main(void) {
+  int rc = test_identity_exchange();
+  if (rc != 0) {
+    fprintf(stderr, "test_identity_exchange failed: %d\n", rc);
+    return rc;
+  }
+  rc = test_parse_challenge();
+  if (rc != 0) {
+    fprintf(stderr, "test_parse_challenge failed: %d\n", rc);
+    return 10 + rc;
+  }
+  rc = test_build_response();
+  if (rc != 0) {
+    fprintf(stderr, "test_build_response failed: %d\n", rc);
+    return 20 + rc;
+  }
+  rc = test_result_exchange();
+  if (rc != 0) {
+    fprintf(stderr, "test_result_exchange failed: %d\n", rc);
+    return 30 + rc;
+  }
+  rc = test_terminal();
+  if (rc != 0) {
+    fprintf(stderr, "test_terminal failed: %d\n", rc);
+    return 40 + rc;
+  }
+  return 0;
+}

--- a/test/native/test_ppp_lcp.c
+++ b/test/native/test_ppp_lcp.c
@@ -2,13 +2,16 @@
 
 #include <stdint.h>
 #include <stdio.h>
+#include <string.h>
 
 #define PROTO_PAP 0xc023u
 #define PROTO_LCP 0xc021u
+#define PROTO_EAP 0xc227u
 
 typedef enum {
   PPP_AUTH_PAP = 0,
   PPP_AUTH_MSCHAPV2,
+  PPP_AUTH_EAP_MSCHAPV2,
   PPP_AUTH_CHAP_MD5,
 } ppp_auth_kind_t;
 
@@ -59,6 +62,11 @@ static int lcp_build_cr(uint8_t *out, size_t cap, uint8_t id, ppp_auth_kind_t au
       out[o++] = 0xc2;
       out[o++] = 0x23;
       out[o++] = 0x81;
+    } else if (auth == PPP_AUTH_EAP_MSCHAPV2) {
+      if (o + 3u > cap) return -1;
+      out[o++] = 4;
+      util_write_be16(out + o, PROTO_EAP);
+      o += 2u;
     } else {
       if (o + 4u > cap) return -1;
       out[o++] = 5;
@@ -150,6 +158,16 @@ static int test_selected_mru_is_preserved(void) {
   return 0;
 }
 
+static int test_eap_authentication_option(void) {
+  uint8_t cr[32];
+  int n = lcp_build_cr(cr, sizeof(cr), 7, PPP_AUTH_EAP_MSCHAPV2, 1400, 1, 0, 1);
+  if (n != 16) return 1;
+  if (!lcp_has_option(cr, (size_t)n, 3)) return 2;
+  const uint8_t expected[] = {0x03, 0x04, 0xc2, 0x27};
+  if (memcmp(cr + 12u, expected, sizeof(expected)) != 0) return 3;
+  return 0;
+}
+
 static int test_reject_accm_and_auth_strips_future_cr(void) {
   uint8_t cr[128];
   int include_accm = 1;
@@ -212,6 +230,11 @@ int main(void) {
   rc = test_reject_accm_and_auth_strips_future_cr();
   if (rc != 0) {
     fprintf(stderr, "test_reject_accm_and_auth_strips_future_cr failed: %d\n", rc);
+    return 1;
+  }
+  rc = test_eap_authentication_option();
+  if (rc != 0) {
+    fprintf(stderr, "test_eap_authentication_option failed: %d\n", rc);
     return 1;
   }
   rc = test_reject_unrelated_option_keeps_accm_and_auth();


### PR DESCRIPTION
## Summary

- negotiate EAP as a PPP LCP authentication protocol
- implement EAP Identity and EAP-MSCHAPv2 challenge/response exchanges
- verify the server AuthenticatorResponse before accepting EAP success
- handle EAP success and failure packets and continue to IPCP after authentication
- add native coverage for EAP packet parsing, response construction, result verification, and LCP negotiation

## Motivation

Some L2TP/IPsec PPP servers select EAP with EAP-MSCHAPv2 instead of direct CHAP-MSCHAPv2. The client currently rejects that authentication option, even though it already contains most of the MS-CHAPv2 cryptographic primitives needed to respond.

This change reuses the existing MS-CHAPv2 implementation and adds the EAP framing and state transitions required for these servers.

## Validation

- native EAP-MSCHAPv2 and LCP tests were added and passed during development
- an Android connection completed EAP-MSCHAPv2 authentication and proceeded to IPCP against a compatible L2TP/IPsec endpoint
- the final public patch contains synthetic test values only; no endpoint, account, credential, or packet-capture data is included

## Notes

- malformed EAP and MS-CHAPv2 lengths are rejected
- the server AuthenticatorResponse is compared in constant time
- credentials and challenge/response values are not logged
